### PR TITLE
chore: update SDK and dependencies in pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.5.35+64
 publish_to: none
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 dependencies:
   breakpoint: ^1.2.0
@@ -13,14 +13,15 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_animate: ^4.5.2
-  go_router: ^16.0.0
+  go_router: ^16.2.0
   intl: ^0.20.2
   json_annotation: ^4.9.0
   material_design_icons_flutter: ^7.0.7296
 
 dev_dependencies:
-  build_runner: ^2.5.4
+  build_runner: ^2.7.0
   flutter_test:
     sdk: flutter
-  json_serializable: ^6.9.5
+  json_serializable: ^6.10.0
   very_good_analysis: ^9.0.0
+  mocktail: ^1.0.4


### PR DESCRIPTION
This pull request updates several dependencies and the Dart SDK version in the `pubspec.yaml` file to keep the project up to date and compatible with newer features. The most important changes include increasing the minimum Dart SDK version and upgrading key dependencies and dev dependencies.

Dependency and SDK updates:

* Increased the minimum Dart SDK version requirement from `>=3.8.0` to `>=3.9.0` to support newer language features.
* Upgraded the `go_router` dependency from version `^16.0.0` to `^16.2.0` for improved routing capabilities.
* Upgraded `build_runner` from `^2.5.4` to `^2.7.0` and `json_serializable` from `^6.9.5` to `^6.10.0` to ensure compatibility with the latest code generation tools.
* Added `mocktail` version `^1.0.4` as a dev dependency for improved testing and mocking support.