### PR TITLE
feat(bullet_point_text): add bullet point text

### DIFF
--- a/lib/common_widgets_flutter.dart
+++ b/lib/common_widgets_flutter.dart
@@ -1,5 +1,6 @@
 export 'src/annotations.dart';
 export 'src/bottom_sheet_handle.dart';
+export 'src/bullet_point_text.dart';
 export 'src/charge_quota_bar_chart.dart';
 export 'src/circular_loader.dart';
 export 'src/coloured_tag.dart';

--- a/lib/src/bullet_point_text.dart
+++ b/lib/src/bullet_point_text.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_adaptive_scaffold/flutter_adaptive_scaffold.dart';
+
+/// A text widget that displays a single bullet (•) or child dash (-) followed by
+/// its content and any nested bullet points.
+///
+/// This widget is intended to be composed recursively to produce multi-level
+/// bullet lists without relying on `ListView` / `ListTile` boilerplate. You can
+/// supply child bullet points via the [bulletPoints] list. Child bullet points
+/// will automatically render with a dash " - " instead of a bullet " • " when
+/// their [isChild] flag is true.
+///
+/// The layout uses a `Row` with a leading symbol and the text in an `Expanded`
+/// column so long lines wrap correctly underneath the text portion rather than
+/// the symbol.
+///
+/// Spacing between nested bullets adapts to the current adaptive scaffold
+/// [Breakpoint] margin to keep visual rhythm across form factors.
+///
+/// Example:
+/// ```dart
+/// BulletPointText(
+///   'Top level bullet',
+///   bulletPoints: const [
+///     BulletPointText('First child', isChild: true),
+///     BulletPointText('Second child', isChild: true),
+///   ],
+/// );
+/// ```
+class BulletPointText extends StatelessWidget {
+  /// Creates a bullet point line of text.
+  ///
+  /// [bulletPoint] is the textual content to display for this bullet.
+  ///
+  /// Provide nested bullet points with [bulletPoints]. When providing nested
+  /// points, set their [isChild] flag to true to render them with the dash
+  /// marker. This widget does not automatically mutate the children's
+  /// [isChild] value so that you retain control over the visual style at each
+  /// level.
+  ///
+  /// Optionally override the default text style using [style]. When [style] is
+  /// provided, the leading symbol receives only right padding; otherwise a top
+  /// and bottom padding is applied for more generous vertical spacing in lists.
+  const BulletPointText(
+    this.bulletPoint, {
+    this.bulletPoints = const [],
+    this.isChild = false,
+    this.style,
+    super.key,
+  });
+
+  /// The textual content for this bullet point line.
+  final String bulletPoint;
+
+  /// Optional nested bullet points to render beneath this one.
+  final List<BulletPointText> bulletPoints;
+
+  /// Whether this instance is considered a child bullet (rendered with a dash).
+  final bool isChild;
+
+  /// Optional override for the text style of both the marker and the text.
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context) {
+    final spacing = Breakpoint.activeBreakpointOf(context).margin;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: style != null
+              ? const EdgeInsets.only(right: 16)
+              : const EdgeInsets.only(top: 4, bottom: 8, right: 24),
+          child: Text(
+            isChild ? ' - ' : ' • ',
+            style: style ?? Theme.of(context).textTheme.bodyLarge,
+          ),
+        ),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                bulletPoint,
+                style: style ?? Theme.of(context).textTheme.bodyLarge,
+              ),
+              if (bulletPoints.isNotEmpty)
+                Padding(
+                  padding: EdgeInsets.only(
+                    top: spacing / 2,
+                    right: spacing / 2,
+                    bottom: spacing / 2,
+                  ),
+                  child: Column(children: bulletPoints),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   equatable: ^2.0.7
   flutter:
     sdk: flutter
+  flutter_adaptive_scaffold: ^0.3.3+1
   flutter_animate: ^4.5.2
   go_router: ^16.2.0
   intl: ^0.20.2

--- a/test/widgets/bullet_point_text_test.dart
+++ b/test/widgets/bullet_point_text_test.dart
@@ -1,0 +1,80 @@
+import 'package:common_widgets_flutter/common_widgets_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('BulletPointText', () {
+    testWidgets('renders bullet marker and text', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            // Not const because BulletPointText is not a const constructor.
+            body: BulletPointText('Hello world'),
+          ),
+        ),
+      );
+
+      expect(find.text(' • '), findsOneWidget);
+      expect(find.text('Hello world'), findsOneWidget);
+    });
+
+    testWidgets('renders child dash marker when isChild=true', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: BulletPointText('Child', isChild: true),
+          ),
+        ),
+      );
+
+      expect(find.text(' - '), findsOneWidget);
+      expect(find.text('Child'), findsOneWidget);
+    });
+
+    testWidgets('renders nested bullet points', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: BulletPointText(
+              'Parent',
+              bulletPoints: [
+                BulletPointText('First child', isChild: true),
+                BulletPointText('Second child', isChild: true),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Parent bullet marker and text
+      expect(find.text(' • '), findsOneWidget);
+      expect(find.text('Parent'), findsOneWidget);
+
+      // Child dash markers (two children)
+      expect(find.text(' - '), findsNWidgets(2));
+      expect(find.text('First child'), findsOneWidget);
+      expect(find.text('Second child'), findsOneWidget);
+    });
+
+    testWidgets('applies custom text style to marker and text', (tester) async {
+      const customStyle = TextStyle(fontSize: 22, color: Colors.purple);
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: BulletPointText('Styled', style: customStyle),
+          ),
+        ),
+      );
+
+      final textWidgets = tester.widgetList<Text>(find.text('Styled'));
+      expect(textWidgets.length, 1);
+      final styledText = textWidgets.first;
+      expect(styledText.style?.fontSize, 22);
+      expect(styledText.style?.color, Colors.purple);
+
+      final markerText = tester.widget<Text>(find.text(' • '));
+      expect(markerText.style?.fontSize, 22);
+      expect(markerText.style?.color, Colors.purple);
+    });
+  });
+}


### PR DESCRIPTION
This pull request introduces a new reusable widget for displaying bullet point lists in Flutter, along with its corresponding tests and dependency updates. The main addition is the `BulletPointText` widget, which allows for flexible and adaptive rendering of nested bullet points with customizable styles.

**New Widget and Feature Additions:**

* Added the new `BulletPointText` widget for rendering bullet and dash-styled list items, supporting nested bullet points and adaptive spacing. (`lib/src/bullet_point_text.dart`)
* Exported `BulletPointText` from the package's main export file for public use. (`lib/common_widgets_flutter.dart`)

**Testing:**

* Added comprehensive widget tests for `BulletPointText`, covering bullet and dash markers, nesting, and custom styling. (`test/widgets/bullet_point_text_test.dart`)

**Dependency Updates:**

* Added `flutter_adaptive_scaffold` as a new dependency to enable adaptive spacing based on breakpoints. (`pubspec.yaml`)