### PR TITLE
chore: weekly dependency audit — fix stale SDK floor

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.5.39+68
 publish_to: none
 
 environment:
-  sdk: ">=3.9.0 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   breakpoint: ^1.2.0


### PR DESCRIPTION
## Summary

Weekly automated Flutter/Dart dependency and deprecation audit.

- Fixed a stale SDK floor: `sdk: ">=3.9.0 <4.0.0"` → `">=3.10.0 <4.0.0"`. The `go_router 17.3.0` we already resolve to under `^17.0.0` itself requires `sdk: ^3.10.0` — our stated floor no longer matched what the package actually needs. Documentation-accuracy fix only; installed stable Dart is 3.12.2, well above either floor.
- No minor/patch bumps needed — every direct dependency (`breakpoint`, `equatable`, `flutter_adaptive_scaffold`, `flutter_animate`, `flutter_material_design_icons`, `go_router`, `intl`, `json_annotation`, `json_serializable`, `mocktail`, `very_good_analysis`) already resolves to latest-for-major under its current constraint.
- No major bumps available/needed right now (checked pub.dev changelogs for all direct deps).
- `flutter_adaptive_scaffold` remains **blocked/discontinued** upstream — still used in `lib/src/bullet_point_text.dart` for `Breakpoint.activeBreakpointOf(context).margin`. Flagging for the same migration effort already tracked in the consuming apps (chargeplus_customer epic #1593); not touched here since it's an app-level migration, not a version bump.
- `build_runner` is blocked one patch behind (2.15.1 vs 2.15.3) by the Flutter SDK's own bundled `meta` version, not by anything in this repo's control — resolves itself when Flutter's bundled `meta` moves forward.
- No deprecated API usage found in `lib/`.
- Tests: 15/15 passing before and after. `dart analyze --fatal-infos lib test` output unchanged (20 pre-existing info-level lints, none new, none deprecation-related).

Note: `.github/dependabot.yaml` already runs daily `pub` + `github-actions` updates here, which appears to already keep routine minor/patch bumps current — this audit's ongoing value for this repo is mainly major-version triage, deprecated-API scanning, and SDK-floor accuracy.

## Type of Change

- [x] ✅ Build configuration change
- [ ] 🧹 Code refactor

---
_Generated by [Claude Code](https://claude.ai/code/session_01PG31qRvLz5UHZ13KzUyFPb)_